### PR TITLE
Force upload of all backend files

### DIFF
--- a/.github/workflows/deploy_backend_main.yml
+++ b/.github/workflows/deploy_backend_main.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Deploy Score and Map to Geoplatform AWS
         if: ${{ env.J40_VERSION_LABEL_STRING == '2.0' }}
         run: |
-          poetry run s4cmd put ./data_pipeline/data/score/* s3://${{secrets.S3_DATA_BUCKET}}/data-versions/${{env.J40_VERSION_LABEL_STRING}}/data/score/ --sync-check --recursive --force --API-ACL=public-read --num-threads=250
-          poetry run s4cmd put ./data_pipeline/files/* s3://${{secrets.S3_DATA_BUCKET}}/data-versions/${{env.J40_VERSION_LABEL_STRING}}/data/score/downloadable/ --sync-check --API-ACL=public-read --recursive --force
+          poetry run s4cmd put ./data_pipeline/data/score/* s3://${{secrets.S3_DATA_BUCKET}}/data-versions/${{env.J40_VERSION_LABEL_STRING}}/data/score/ --recursive --force --API-ACL=public-read --num-threads=250
+          poetry run s4cmd put ./data_pipeline/files/* s3://${{secrets.S3_DATA_BUCKET}}/data-versions/${{env.J40_VERSION_LABEL_STRING}}/data/score/downloadable/ --recursive --force --API-ACL=public-read
           poetry run s4cmd put ./data_pipeline/data/tribal/* s3://${{secrets.S3_DATA_BUCKET}}/data-versions/${{env.J40_VERSION_LABEL_STRING}}/data/tribal/ --recursive --force --API-ACL=public-read --num-threads=250
       - name: 2.0 Post-deploy Score Check
         run: |


### PR DESCRIPTION
This change alters the upload of the backend files to no longer skip uploading of the same file to the s3 bucket. The upload will now overwrite a file even if it has the same checksum. This is needed because some files were initially uploaded without the correct acl applied and there is no easy way to find and re-apply the acl to files that may need it. This brute force method will ensure all files have the acl applied. The better way to do this would be to change the way the s3 bucket and cloudfront distribution is configured to not need an acl, but that is something than can be looked at after deployment of 2.0